### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ If you are using Node.js, you can just install the `ohm-js` package using [npm](
 
 This will install Ohm in the local node_modules folder. Use `require` to access it from a Node script:
 
-    ```js
-    var ohm = require('ohm-js');
-    ```
+```js
+var ohm = require('ohm-js');
+```
 
 ### Basics
 


### PR DESCRIPTION
GitHub doesn't deal well with root level indented code blocks in Markdown. (Treats the ```js as part of the code block)