### PR TITLE
Refactoring ES5 grammar to be more idiomatic

### DIFF
--- a/examples/ecmascript/es5.ohm
+++ b/examples/ecmascript/es5.ohm
@@ -273,15 +273,13 @@ ES5 {
                     | "(" Expression ")"  -- parenExpr
 
   // @returns an ArrayExpr AST
-  ArrayLiteral = "[" AssignmentExpressionOrElisionComma* "]"                       -- trailingComma
-               | "[" AssignmentExpressionOrElisionComma* AssignmentExpression "]"  -- noTrailingComma
-  AssignmentExpressionOrElisionComma = (AssignmentExpression | Elision) ","
-  Elision =
+  ArrayLiteral = "[" ListOf<AssignmentExpressionOrElision, ","> "]"
+  AssignmentExpressionOrElision = AssignmentExpression
+                                |                       -- elision
 
   // @returns an ObjectExpr AST
-  ObjectLiteral = "{" PropertyAssignmentComma* "}" -- trailingComma
-                | "{" PropertyAssignmentComma* PropertyAssignment "}" -- noTrailingComma
-  PropertyAssignmentComma = PropertyAssignment ","
+  ObjectLiteral = "{" ListOf<PropertyAssignment, ","> "}"              -- noTrailingComma
+                | "{" NonemptyListOf<PropertyAssignment, ","> "," "}"  -- trailingComma
 
   // @returns a *Prop AST
   PropertyAssignment = get PropertyName "(" ")" "{" FunctionBody "}"                  -- getter
@@ -311,14 +309,7 @@ ES5 {
                  | MemberExpression Arguments         -- memberExpExp
 
   // @returns an array of ASTs
-  Arguments = "(" ")"                -- empty
-            | "(" ArgumentList ")"   -- nonEmpty
-
-  // @returns an array of ASTs
-  ArgumentList = AssignmentExpressionComma* AssignmentExpression -- many
-               | AssignmentExpression                            -- one
-
-  AssignmentExpressionComma = AssignmentExpression ","
+  Arguments = "(" ListOf<AssignmentExpression, ","> ")"
 
   LeftHandSideExpression = CallExpression
                          | NewExpression
@@ -432,17 +423,10 @@ ES5 {
   VariableStatement = var VariableDeclarationList #(sc)
 
   // @returns an array of ASTs
-  VariableDeclarationList = VariableDeclarationComma* VariableDeclaration -- many
-                          | VariableDeclaration
-
-  VariableDeclarationComma = VariableDeclaration ","
+  VariableDeclarationList = NonemptyListOf<VariableDeclaration, ",">
 
   // @returns an AST
-  VariableDeclaration = InitPattern  -- initialValue
-                      | identifier   -- noInitialValue
-
-  // @returns an AST
-  InitPattern = identifier Initialiser
+  VariableDeclaration = identifier Initialiser?
 
   // @returns an AST
   Initialiser = "=" AssignmentExpression
@@ -454,8 +438,7 @@ ES5 {
   ExpressionStatement = ~("{" | function) Expression #(sc)
 
   // @returns an AST
-  IfStatement = if "(" Expression ")" Statement else Statement  -- ifThenElse
-              | if "(" Expression ")" Statement                 -- ifThen
+  IfStatement = if "(" Expression ")" Statement (else Statement)?
 
   // @returns an AST
   IterationStatement = do Statement while "(" Expression ")" #(sc)  -- doWhile
@@ -515,10 +498,7 @@ ES5 {
     | function "(" FormalParameterList ")" "{" FunctionBody "}"             -- anonymous
 
   // @returns an array of ASTs
-  FormalParameterList = FormalParameter (CommaFormalParameter)* -- many
-                      |                                         -- zero
-
-  CommaFormalParameter = "," FormalParameter
+  FormalParameterList = ListOf<FormalParameter, ",">
 
   // @returns an AST
   FormalParameter = identifier


### PR DESCRIPTION
The original ES5 grammar for Ohm is based on OMeta's grammar which in fact is very close to the Appendix A of the ECMAScript 5.1 spec (ECMA-262). This makes it less idiomatic to Ohm and a manual creation of this grammar would look very different, I think.
Here are some refactorings to make the ES5 grammar use more of the Ohm features (not available in grammar notation of the spec).