### PR TITLE
Don't duplicate formal arguments

### DIFF
--- a/examples/math/index.html
+++ b/examples/math/index.html
@@ -268,15 +268,15 @@ s.addOperation(
       /*
         The following semantic actions are more of the same...
       */
-      MulExp:        function(e)       { return e.interpret(); },
-      MulExp_times:  function(x, _, y) { return x.interpret() * y.interpret(); },
-      MulExp_divide: function(x, _, y) { return x.interpret() / y.interpret(); },
-      ExpExp:        function(e)       { return e.interpret(); },
-      ExpExp_power:  function(x, _, y) { return Math.pow(x.interpret(), y.interpret()); },
-      PriExp:        function(e)       { return e.interpret(); },
-      PriExp_paren:  function(_, e, _) { return e.interpret(); },
-      PriExp_pos:    function(_, e)    { return e.interpret(); },
-      PriExp_neg:    function(_, e)    { return -e.interpret(); },
+      MulExp:        function(e)         { return e.interpret(); },
+      MulExp_times:  function(x, _, y)   { return x.interpret() * y.interpret(); },
+      MulExp_divide: function(x, _, y)   { return x.interpret() / y.interpret(); },
+      ExpExp:        function(e)         { return e.interpret(); },
+      ExpExp_power:  function(x, _, y)   { return Math.pow(x.interpret(), y.interpret()); },
+      PriExp:        function(e)         { return e.interpret(); },
+      PriExp_paren:  function(_l, e, _r) { return e.interpret(); },
+      PriExp_pos:    function(_, e)      { return e.interpret(); },
+      PriExp_neg:    function(_, e)      { return -e.interpret(); },
 
       /*
         All CST nodes have an `interval` property whose value is an object that contains information
@@ -293,7 +293,7 @@ s.addOperation(
         In other words, `this` is the parent of each of the CST nodes that are passed as arguments
         to the semantic action.)
       */
-      ident: function(_, _) {
+      ident: function(_l, _ns) {
         // Look up the value of a named constant, e.g., 'pi'.
         return constants[this.interval.contents] || 0;
       },
@@ -321,16 +321,16 @@ console.log(n.interpret()); // ... on which you can access the functionality pro
 */
 
 s.addAttribute('asLisp', {
-  AddExp_plus:   function(x, _, y) { return ['+', x.asLisp, y.asLisp]; },
-  AddExp_minus:  function(x, _, y) { return ['-', x.asLisp, y.asLisp]; },
-  MulExp_times:  function(x, _, y) { return ['*', x.asLisp, y.asLisp]; },
-  MulExp_divide: function(x, _, y) { return ['/', x.asLisp, y.asLisp]; },
-  ExpExp_power:  function(x, _, y) { return ['pow', x.asLisp, y.asLisp]; },
-  PriExp_paren:  function(_, e, _) { return e.asLisp; },
-  PriExp_pos:    function(_, e)    { return e.asLisp; },
-  PriExp_neg:    function(_, e)    { return ['neg', e.asLisp]; },
-  ident:         function(_, _)    { return this.interval.contents; },
-  number:        function(_)       { return this.interval.contents; },
+  AddExp_plus:   function(x, _, y)   { return ['+', x.asLisp, y.asLisp]; },
+  AddExp_minus:  function(x, _, y)   { return ['-', x.asLisp, y.asLisp]; },
+  MulExp_times:  function(x, _, y)   { return ['*', x.asLisp, y.asLisp]; },
+  MulExp_divide: function(x, _, y)   { return ['/', x.asLisp, y.asLisp]; },
+  ExpExp_power:  function(x, _, y)   { return ['pow', x.asLisp, y.asLisp]; },
+  PriExp_paren:  function(_l, e, _r) { return e.asLisp; },
+  PriExp_pos:    function(_, e)      { return e.asLisp; },
+  PriExp_neg:    function(_, e)      { return ['neg', e.asLisp]; },
+  ident:         function(_l, _ns)   { return this.interval.contents; },
+  number:        function(_)         { return this.interval.contents; },
 
   /*
     When you create an operation or an attribute, you can optionally provide a `_nonterminal`
@@ -380,31 +380,31 @@ s.addOperation('toTree', {
   PriExp_paren:  function(op, e, cp) { return elt('paren', op.toTree(), e.toTree(), cp.toTree()); },
   PriExp_pos:    function(sign, e)   { return elt('pos', sign.toTree(), e.toTree()); },
   PriExp_neg:    function(sign, e)   { return elt('neg', sign.toTree(), e.toTree()); },
-  ident:         function(_, _)      { return elt('ident', this.interval.contents); },
+  ident:         function(_l, _ns)   { return elt('ident', this.interval.contents); },
   number:        function(_)         { return elt('number', this.interval.contents); }
 });
 
 // -------------------------------------------------------------------------------------------------
 
 s.addOperation('toTwoD', {
-  AddExp_plus:   function(x, op, y) { var operator = elt('operator', op.toTwoD());
-                                      return elt('plus', x.toTwoD(), operator, y.toTwoD()); },
-  AddExp_minus:  function(x, op, y) { var operator = elt('operator', '\u2212');
-                                      return elt('minus', x.toTwoD(), operator, y.toTwoD()); },
-  MulExp_times:  function(x, op, y) { var operator = elt('operator', '\u00D7');
-                                      return elt('times', x.toTwoD(), operator, y.toTwoD()); },
-  MulExp_divide: function(x, op, y) { var numerator = elt('numerator', x.toTwoD());
-                                      var denominator = elt('denominator', y.toTwoD());
-                                      return elt('fraction', numerator, denominator); },
-  ExpExp_power:  function(x, op, y) { var base = elt('theBase', x.toTwoD());
-                                      var exponent = elt('exponent', y.toTwoD());
-                                      return elt('power', base, exponent); },
-  PriExp_paren:  function(_, e, _)  { return elt('paren', e.toTwoD()); },
-  PriExp_pos:    function(sign, e)  { return elt('pos', sign.toTwoD(), e.toTwoD()); },
-  PriExp_neg:    function(sign, e)  { return elt('neg', sign.toTwoD(), e.toTwoD()); },
-  ident:         function(_, _)     { var text = this.interval.contents;
-                                      return elt('ident', text === 'pi' ? '\u03C0' : text); },
-  number:        function(_)        { return elt('number', this.interval.contents); }
+  AddExp_plus:   function(x, op, y)   { var operator = elt('operator', op.toTwoD());
+                                        return elt('plus', x.toTwoD(), operator, y.toTwoD()); },
+  AddExp_minus:  function(x, op, y)   { var operator = elt('operator', '\u2212');
+                                        return elt('minus', x.toTwoD(), operator, y.toTwoD()); },
+  MulExp_times:  function(x, op, y)   { var operator = elt('operator', '\u00D7');
+                                        return elt('times', x.toTwoD(), operator, y.toTwoD()); },
+  MulExp_divide: function(x, op, y)   { var numerator = elt('numerator', x.toTwoD());
+                                        var denominator = elt('denominator', y.toTwoD());
+                                        return elt('fraction', numerator, denominator); },
+  ExpExp_power:  function(x, op, y)   { var base = elt('theBase', x.toTwoD());
+                                        var exponent = elt('exponent', y.toTwoD());
+                                        return elt('power', base, exponent); },
+  PriExp_paren:  function(_l, e, _r)  { return elt('paren', e.toTwoD()); },
+  PriExp_pos:    function(sign, e)    { return elt('pos', sign.toTwoD(), e.toTwoD()); },
+  PriExp_neg:    function(sign, e)    { return elt('neg', sign.toTwoD(), e.toTwoD()); },
+  ident:         function(_l, _ns)    { var text = this.interval.contents;
+                                        return elt('ident', text === 'pi' ? '\u03C0' : text); },
+  number:        function(_)          { return elt('number', this.interval.contents); }
 
   // Remember the `_nonterminal` semantic action that we wrote for the `interpret` operation above?
   // Turns out that's so convenient that the Ohm people decided to give it to you "for free", i.e.,

--- a/examples/pl0/index.html
+++ b/examples/pl0/index.html
@@ -112,7 +112,7 @@ s.addAttribute('symbolTableOut', {
   Start: function(q) {
     return q.symbolTableOut;
   },
-  Stmt_var: function(_, n, _, e, _) {
+  Stmt_var: function(_var, n, _eq, e, _sc) {
     return [].concat(symbolTableIn(this)).concat([n.interval.contents]);
   },
   _nonterminal: function(children) {
@@ -133,18 +133,18 @@ s.addAttribute('codeOut', {
   Seq_base: function(s) {
     return s.codeOut;
   },
-  Stmt_var: function(_, n, _, e, _) {
+  Stmt_var: function(_var, n, _eq, e, _sc) {
     return [].concat(e.codeOut)
              .concat(['pushLit(' + this.symbolTableOut.indexOf(n.interval.contents) + ')', 'store']);
   },
-  Stmt_print: function(_, e, _) {
+  Stmt_print: function(_print, e, _sc) {
     return [].concat(e.codeOut).concat(['print']);
   },
-  Stmt_assign: function(n, _, e, _) {
+  Stmt_assign: function(n, _eq, e, _sc) {
     return [].concat(e.codeOut(e))
              .concat(['pushLit(' + this.symbolTableOut.indexOf(n.interval.contents) + ')', 'store']);
   },
-  Stmt_if3: function(_, c, _, t, _, f) {
+  Stmt_if3: function(_if, c, _then, t, _else, f) {
     var tCode = t.codeOut;
     var fCode = f.codeOut;
     return [].concat(c.codeOut)
@@ -154,7 +154,7 @@ s.addAttribute('codeOut', {
              .concat(fCode);
   },
 
-  Stmt_if2: function(_, c, _, t) {
+  Stmt_if2: function(_if, c, _then, t) {
     var tCode = t.codeOut;
     return [].concat(c.codeOut)
              .concat(['jmp0(' + tCode.length + ')'])
@@ -172,7 +172,7 @@ s.addAttribute('codeOut', {
   MulExpr_divide: function(x, _, y) {
     return [].concat(x.codeOut).concat(y.codeOut).concat(['div']);
   },
-  PriExpr_paren: function(_, e, _) {
+  PriExpr_paren: function(_l, e, _r) {
     return e.codeOut;
   },
   PriExpr_pos: function(_, e) {
@@ -181,7 +181,7 @@ s.addAttribute('codeOut', {
   PriExpr_neg: function(_, e) {
     return [].concat([e.codeOut]).concat(['neg']);
   },
-  ident: function(_, _) {
+  ident: function(_l, _ns) {
     return ['pushReg(' + this.symbolTableOut.indexOf(this.interval.contents) + ')'];
   },
   number: function(_) {

--- a/examples/pl0/index.html
+++ b/examples/pl0/index.html
@@ -22,7 +22,7 @@
 
 PL0 {
 
-  Start 
+  Start
     = Seq
 
   Seq
@@ -70,7 +70,7 @@ PL0 {
   else  = "else" ~alnum
 
   keyword = var | print | if | then | else
-  
+
 }
 
     </script>

--- a/examples/viz/index.html
+++ b/examples/viz/index.html
@@ -117,7 +117,7 @@ function add(/* tagName, child1, child2, ... */) {
 var s = ohm.ohmGrammar.semantics();
 
 s.addOperation('viz', {
-  Grammar:           function(n, s, _, rs, _) {
+  Grammar:           function(n, s, _l, rs, _r) {
                        enter('grammar');
                          add('name', n.viz());
                          s.viz();
@@ -155,7 +155,7 @@ s.addOperation('viz', {
                          b.viz();
                        leave();
                      },
-  ruleDescr:         function(_, t, _) {
+  ruleDescr:         function(_l, t, _r) {
                        add('description', t.viz());
                      },
   ruleDescrText:     function(_) {
@@ -174,7 +174,7 @@ s.addOperation('viz', {
                        x.viz();
                        n.viz();
                      },
-  caseName:          function(_, _, n, _, _) {
+  caseName:          function(_d, _s1, n, _s2, _t) {
                        add('caseName', n.viz());
                      },
   Seq:               function(expr) {
@@ -222,20 +222,20 @@ s.addOperation('viz', {
   Base_prim:         function(expr) {
                        expr.viz();
                      },
-  Base_paren:        function(_, x, _) {
+  Base_paren:        function(_l, x, _r) {
                        enter('paren');
                          x.viz();
                        leave();
                      },
-  Base_arr:          function(_, x, _) {
+  Base_arr:          function(_l, x, _r) {
                        enter('arr');
                          x.viz();
                        leave();
                      },
-  Base_obj:          function(_, lenient, _) {
+  Base_obj:          function(_l, lenient, _r) {
                        throw 'TODO';
                      },
-  Base_objWithProps: function(_, ps, _, lenient, _) {
+  Base_objWithProps: function(_l, ps, _c, lenient, _r) {
                        throw 'TODO';
                      },
   Props:             function(p, _, ps) {
@@ -244,13 +244,13 @@ s.addOperation('viz', {
   ident:             function(n) {
                        return n.viz();
                      },
-  name:              function(_, _) {
+  name:              function(_first, _rest) {
                        return this.interval.contents;
                      },
-  string:            function(_, cs, _) {
+  string:            function(_lq, cs, _rq) {
                        add('string', escape(eval(this.interval.contents)));
                      },
-  number:            function(_, _) {
+  number:            function(_neg, _digits) {
                        add('prim', this.interval.contents);
                      },
   keyword:           function(expr) {


### PR DESCRIPTION
Instead, give unused arguments distinct, descriptive names that start with a leading underscore. This pattern is preferable because it is compatible with strict mode.

Fixes #54.

Note: I checked that the math and viz examples continued to work after this change. The pl0 example was broken before I started; I think it needs maintenance to be brought up to speed with master, but I'm probably the wrong person to do it.