### PR TITLE
toJson for Grammar and PExpr

### DIFF
--- a/src/Grammar.js
+++ b/src/Grammar.js
@@ -141,6 +141,54 @@ Grammar.prototype = {
     return false;
   },
 
+  toJson: function() {
+    var blob = {};
+    blob.name = this.name;
+    if (this.superGrammar) {
+      blob.superGrammar = this.superGrammar.name;
+    }
+    if (this.defaultStartRule) {
+      blob.defaultStartRule = this.defaultStartRule;
+    }
+    var definitions = {};
+    var extensions = {};
+    var overrides = {};
+    blob.definitions = definitions;
+    blob.extensions = extensions;
+    blob.overrides = overrides;
+    var self = this;
+    Object.keys(this.ruleBodies).forEach(function(ruleName) {
+      var body = self.ruleBodies[ruleName];
+      var formals = self.ruleFormals[ruleName];
+      var rule = {};
+      rule.name = ruleName;
+      rule.formals = formals;
+      rule.body = body.toJson(formals);
+      if (self.superGrammar && self.superGrammar.ruleBodies[ruleName]) {
+        (body instanceof pexprs.Extend ? extensions : overrides)[ruleName] = rule;
+      } else {
+        if (self.ruleDescriptions[ruleName]) {
+          rule.description = self.ruleDescriptions[ruleName];
+        }
+        definitions[ruleName] = rule;
+      }
+    });
+    return blob;
+  },
+
+  jsonHierarchy: function() {
+    var grammars = {};
+    var g = this;
+    while (g) {
+      grammars[g.name] = g.toJson();
+      g = g.superGrammar;
+    }
+    return {
+      startGrammar: this.name,
+      grammars: grammars
+    };
+  },
+
   toRecipe: function(optVarName) {
     if (this.isBuiltIn()) {
       throw new Error(

--- a/src/pexprs-toJson.js
+++ b/src/pexprs-toJson.js
@@ -1,0 +1,170 @@
+'use strict';
+
+// --------------------------------------------------------------------
+// Imports
+// --------------------------------------------------------------------
+
+var common = require('./common');
+var pexprs = require('./pexprs');
+
+// --------------------------------------------------------------------
+// Operations
+// --------------------------------------------------------------------
+
+pexprs.PExpr.prototype.toJson = common.abstract;
+
+pexprs.any.toJson = function(formals) {
+  return {
+    type: 'any'
+  };
+};
+
+pexprs.end.toJson = function(formals) {
+  return {
+    type: 'end'
+  };
+};
+
+pexprs.Prim.prototype.toJson = function(formals) {
+  return {
+    type: 'prim',
+    obj: this.obj
+  };
+};
+
+pexprs.Range.prototype.toJson = function(formals) {
+  return {
+    type: 'range',
+    from: this.from,
+    to: this.to
+  };
+};
+
+pexprs.Param.prototype.toJson = function(formals) {
+  return {
+    type: 'param',
+    index: this.index
+  };
+};
+
+pexprs.Alt.prototype.toJson = function(formals) {
+  return {
+    type: 'alt',
+    terms: this.terms.map(function(t) { return t.toJson(formals); })
+  };
+};
+
+pexprs.Extend.prototype.toJson = function(formals) {
+  return this.terms[0].toJson(formals);
+};
+
+pexprs.Seq.prototype.toJson = function(formals) {
+  return {
+    type: 'seq',
+    factors: this.factors.map(function(f) { return f.toJson(formals); })
+  };
+};
+
+pexprs.Star.prototype.toJson = function(formals) {
+  return {
+    type: 'star',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Plus.prototype.toJson = function(formals) {
+  return {
+    type: 'plus',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Opt.prototype.toJson = function(formals) {
+  return {
+    type: 'opt',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Not.prototype.toJson = function(formals) {
+  return {
+    type: 'not',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Lookahead.prototype.toJson = function(formals) {
+  return {
+    type: 'lookahead',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Lex.prototype.toJson = function(formals) {
+  return {
+    type: 'lex',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Value.prototype.toJson = function(formals) {
+  return {
+    type: 'val',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Arr.prototype.toJson = function(formals) {
+  return {
+    type: 'arr',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Str.prototype.toJson = function(formals) {
+  return {
+    type: 'str',
+    expr: this.expr.toJson(formals)
+  };
+};
+
+pexprs.Obj.prototype.toJson = function(formals) {
+  return {
+    type: 'obj',
+    lenient: !!this.isLenient,
+    properties: this.properties.map(function(p) {
+      return {
+        name: p.name,
+        pattern: p.pattern.toJson(formals)
+      };
+    })
+  };
+};
+
+pexprs.Apply.prototype.toJson = function(formals) {
+  var args;
+  if (this.ruleName.indexOf('_') >= 0 && formals.length > 0) {
+    args = formals;
+  } else if (this.args.length > 0) {
+    args = this.args.map(function(arg) { return arg.toJson(formals); });
+  }
+  return {
+    type: 'app',
+    rule: this.ruleName,
+    args: args
+  };
+};
+
+pexprs.UnicodeChar.prototype.toJson = function(formals) {
+  return {
+    type: 'unicodeChar',
+    category: this.category
+  };
+};
+
+pexprs.TypeCheck.prototype.toJson = function(formals) {
+  return {
+    type: 'typeCheck',
+    expectedType: this.type
+  };
+};

--- a/src/pexprs.js
+++ b/src/pexprs.js
@@ -236,3 +236,4 @@ require('./pexprs-toDisplayString');
 require('./pexprs-toArgumentNameList');
 require('./pexprs-toFailure');
 require('./pexprs-toString');
+require('./pexprs-toJson');


### PR DESCRIPTION
The idea here is that one ought to be able to export a grammar using a plain data representation that can be read by *hypothetical* other implementations of Ohm.

For example,

```js
var ohm = require("ohm");
console.log(JSON.stringify(ohm.ohmGrammar.jsonHierarchy(), null, 2));
```

produces a JSON description of the core Ohm grammar.

I am finding this useful, for myself; is this a worthwhile thing to include in the package, for everybody?

(ETA: Comments and suggestions on style and functionality very welcome!)