### PR TITLE
Refactoring the visualizer parts

### DIFF
--- a/test/test-visualizer.js
+++ b/test/test-visualizer.js
@@ -76,10 +76,11 @@ var HTML = '<div id="expandedInput"></div><div id="parseResults"></div>' +
 
 test('simple parse tree', function(t) {
   var doc = jsdom.jsdom(HTML);
-  var refreshParseTree = parseTree(ohm, doc, null, null);
+  var ohmEditor = {};
+  parseTree(ohm, ohmEditor, doc, null, null);
   var g = ohm.grammar('G { start = letter digit+  -- x\n| digit }');
 
-  refreshParseTree(null, g, g.trace('a99'), false);
+  ohmEditor.refreshParseTree(null, g, g.trace('a99'), false);
   t.equal(doc.querySelector('#expandedInput').textContent, 'a99');
 
   t.deepEqual(serializeTrace(doc.querySelector('#parseResults')), [

--- a/visualizer/externalRules.js
+++ b/visualizer/externalRules.js
@@ -1,9 +1,16 @@
 /* eslint-env browser */
-/* global $, ohm */
+/* global $ */
 
 'use strict';
 
-var updateExternalRules = (function() {  // eslint-disable-line no-unused-vars
+(function(root, initModule) {
+  if (typeof exports === 'object') {
+    module.exports = initModule;
+  } else {
+    root.ohmEditor = root.ohmEditor || {};
+    initModule(root.ohm, root.ohmEditor);
+  }
+})(this, function(ohm, ohmEditor) {
   var ohmGrammar = ohm.ohmGrammar;
   var builtInRules = ohm.grammar('G {}').superGrammar;
 
@@ -133,10 +140,10 @@ var updateExternalRules = (function() {  // eslint-disable-line no-unused-vars
   var widget;
 
   // Export: a function to be called when the grammar contents change.
-  return function(editor, matchResult, grammar) {
+  ohmEditor.updateExternalRules = function(editor, matchResult, grammar) {
     if (!widget) {
       widget = new LastLineWidget(editor);
     }
     widget.update(editor, matchResult, grammar);
   };
-})();
+});

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -1,198 +1,212 @@
 /* eslint-env browser */
-/* global cmUtil, CodeMirror, ohm, refreshParseTree, searchBar */
-/* global updateExternalRules, updateRuleHyperlinks */
 
 'use strict';
 
 function $(sel) { return document.querySelector(sel); }
-function $$(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); }
-var options = {};
 
-var inputEditor = CodeMirror($('#inputContainer .editorWrapper'));
-var grammarEditor = CodeMirror($('#grammarContainer .editorWrapper'));
-
-// Expose the grammar globally so that it can easily be accessed from the console.
-var grammar = null;
-
-// Misc Helpers
-// ------------
-
-var errorMarks = {
-  grammar: null,
-  input: null
-};
-
-function hideError(category, editor) {
-  var errInfo = errorMarks[category];
-  if (errInfo) {
-    errInfo.mark.clear();
-    clearTimeout(errInfo.timeout);
-    if (errInfo.widget) {
-      errInfo.widget.clear();
-    }
-    errorMarks[category] = null;
-  }
-}
-
-function setError(category, editor, interval, message) {
-  hideError(category, editor);
-
-  errorMarks[category] = {
-    mark: cmUtil.markInterval(editor, interval, 'error-interval', false),
-    timeout: setTimeout(function() { showError(category, editor, interval, message); }, 1500),
-    widget: null
-  };
-}
-
-function showError(category, editor, interval, message) {
-  var errorEl = document.createElement('div');
-  errorEl.className = 'error';
-  errorEl.textContent = message;
-  var line = editor.posFromIndex(interval.endIdx).line;
-  errorMarks[category].widget = editor.addLineWidget(line, errorEl, {insertAt: 0});
-}
-
-function hideBottomOverlay() {
-  $('#bottomSection .overlay').style.width = 0;
-}
-
-function showBottomOverlay() {
-  $('#bottomSection .overlay').style.width = '100%';
-}
-
-function restoreEditorState(editor, key, defaultEl) {
-  var value = localStorage.getItem(key);
-  if (value) {
-    editor.setValue(value);
-  } else if (defaultEl) {
-    editor.setValue(defaultEl.textContent);
-  }
-}
-
-function saveEditorState(editor, key) {
-  localStorage.setItem(key, editor.getValue());
-}
-
-function parseGrammar(source) {
-  var matchResult = ohm.ohmGrammar.match(source);
-  var grammar;
-  var err;
-
-  if (matchResult.succeeded()) {
-    var ns = {};
-    try {
-      ohm._buildGrammar(matchResult, ns);
-      var firstProp = Object.keys(ns)[0];
-      if (firstProp) {
-        grammar = ns[firstProp];
-      }
-    } catch (ex) {
-      err = ex;
-    }
+(function(root, initModule) {
+  if (typeof exports === 'object') {
+    module.exports = initModule;
   } else {
-    err = {
-      message: matchResult.message,
-      shortMessage: matchResult.shortMessage,
-      interval: matchResult.getInterval()
+    root.ohmEditor = root.ohmEditor || {};
+    initModule(root.ohm, root.ohmEditor, root.cmUtil, root.CodeMirror);
+  }
+})(this, function(ohm, ohmEditor, cmUtil, CodeMirror) {
+  function $$(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); }
+
+  var checkboxes, grammarChanged;
+
+  // EXPORTS
+  // -------
+
+  ohmEditor.options = {};
+  ohmEditor.ui = {
+    inputEditor: CodeMirror($('#inputContainer .editorWrapper')),
+    grammarEditor: CodeMirror($('#grammarContainer .editorWrapper'))
+  };
+  ohmEditor.grammar = null;
+
+  ohmEditor.parseGrammar = function() {
+    var source = this.ui.grammarEditor.getValue();
+    var matchResult = ohm.ohmGrammar.match(source);
+    var grammar;
+    var err;
+
+    if (matchResult.succeeded()) {
+      var ns = {};
+      try {
+        ohm._buildGrammar(matchResult, ns);
+        var firstProp = Object.keys(ns)[0];
+        if (firstProp) {
+          grammar = ns[firstProp];
+        }
+      } catch (ex) {
+        err = ex;
+      }
+    } else {
+      err = {
+        message: matchResult.message,
+        shortMessage: matchResult.shortMessage,
+        interval: matchResult.getInterval()
+      };
+    }
+    return {
+      matchResult: matchResult,
+      grammar: grammar,
+      error: err
+    };
+  };
+
+  ohmEditor.refresh = function() {
+    hideError('input', this.ui.inputEditor);
+    saveEditorState(this.ui.inputEditor, 'input');
+
+    // Refresh the option values.
+    for (var i = 0; i < checkboxes.length; ++i) {
+      var checkbox = checkboxes[i];
+      this.options[checkbox.name] = checkbox.checked;
+    }
+
+    if (grammarChanged) {
+      grammarChanged = false;
+      saveEditorState(this.ui.grammarEditor, 'grammar');
+
+      var result = this.parseGrammar();
+      this.grammar = result.grammar;
+      this.updateExternalRules(this.ui.grammarEditor, result.matchResult, this.grammar);
+      this.updateRuleHyperlinks(this.ui.grammarEditor, result.matchResult, this.grammar);
+      if (result.error) {
+        var err = result.error;
+        setError('grammar', this.ui.grammarEditor, err.interval,
+          err.shortMessage || err.message);
+        return;
+      }
+    }
+
+    if (this.grammar && this.grammar.defaultStartRule) {
+      // TODO: Move this stuff to parseTree.js. We probably want a proper event system,
+      // with events like 'beforeGrammarParse' and 'afterGrammarParse'.
+      hideBottomOverlay();
+
+      var trace = this.grammar.trace(this.ui.inputEditor.getValue());
+      if (trace.result.failed()) {
+        // Intervals with start == end won't show up in CodeMirror.
+        var interval = trace.result.getInterval();
+        interval.endIdx += 1;
+        setError('input', this.ui.inputEditor, interval,
+          'Expected ' + trace.result.getExpectedText());
+      }
+
+      this.refreshParseTree(this.ui, this.grammar, trace, this.options.showFailures);
+    }
+  };
+
+  // Misc Helpers
+  // ------------
+
+  var errorMarks = {
+    grammar: null,
+    input: null
+  };
+
+  function hideError(category, editor) {
+    var errInfo = errorMarks[category];
+    if (errInfo) {
+      errInfo.mark.clear();
+      clearTimeout(errInfo.timeout);
+      if (errInfo.widget) {
+        errInfo.widget.clear();
+      }
+      errorMarks[category] = null;
+    }
+  }
+
+  function setError(category, editor, interval, message) {
+    hideError(category, editor);
+
+    errorMarks[category] = {
+      mark: cmUtil.markInterval(editor, interval, 'error-interval', false),
+      timeout: setTimeout(showError.bind(null, category, editor, interval, message), 1500),
+      widget: null
     };
   }
-  return {
-    matchResult: matchResult,
-    grammar: grammar,
-    error: err
-  };
-}
 
-// Main
-// ----
+  function showError(category, editor, interval, message) {
+    var errorEl = document.createElement('div');
+    errorEl.className = 'error';
+    errorEl.textContent = message;
+    var line = editor.posFromIndex(interval.endIdx).line;
+    errorMarks[category].widget = editor.addLineWidget(line, errorEl, {insertAt: 0});
+  }
 
-(function main() {
-  var checkboxes = document.querySelectorAll('#options input[type=checkbox]');
+  function hideBottomOverlay() {
+    $('#bottomSection .overlay').style.width = 0;
+  }
+
+  function showBottomOverlay() {
+    $('#bottomSection .overlay').style.width = '100%';
+  }
+
+  function restoreEditorState(editor, key, defaultEl) {
+    var value = localStorage.getItem(key);
+    if (value) {
+      editor.setValue(value);
+    } else if (defaultEl) {
+      editor.setValue(defaultEl.textContent);
+    }
+  }
+
+  function saveEditorState(editor, key) {
+    localStorage.setItem(key, editor.getValue());
+  }
+
+  // Main
+  // ----
+
   var refreshTimeout;
-  var grammarChanged = true;
-
-  searchBar.initializeForEditor(inputEditor);
-  searchBar.initializeForEditor(grammarEditor);
-
-  var ui = {
-    grammarEditor: grammarEditor,
-    inputEditor: inputEditor
-  };
-
   function triggerRefresh(delay) {
     showBottomOverlay();
     if (refreshTimeout) {
       clearTimeout(refreshTimeout);
     }
-    refreshTimeout = setTimeout(refresh, delay || 0);
+    refreshTimeout = setTimeout(ohmEditor.refresh.bind(ohmEditor), delay || 0);
   }
+
+  checkboxes = document.querySelectorAll('#options input[type=checkbox]');
   Array.prototype.forEach.call(checkboxes, function(cb) {
     cb.addEventListener('click', function(e) { triggerRefresh(); });
   });
 
-  restoreEditorState(inputEditor, 'input', $('#sampleInput'));
-  restoreEditorState(grammarEditor, 'grammar', $('#sampleGrammar'));
+  ohmEditor.searchBar.initializeForEditor(ohmEditor.ui.inputEditor);
+  ohmEditor.searchBar.initializeForEditor(ohmEditor.ui.grammarEditor);
 
-  inputEditor.on('change', function() { triggerRefresh(250); });
-  grammarEditor.on('change', function() {
-    grammarChanged = true;
-    hideError('grammar', grammarEditor);
+  restoreEditorState(ohmEditor.ui.inputEditor, 'input', $('#sampleInput'));
+  restoreEditorState(ohmEditor.ui.grammarEditor, 'grammar', $('#sampleGrammar'));
+
+  ohmEditor.ui.inputEditor.on('change', function() {
+    hideError('input', ohmEditor.ui.inputEditor);
     triggerRefresh(250);
   });
-
-  function refresh() {
-    hideError('input', inputEditor);
-    saveEditorState(inputEditor, 'input');
-
-    // Refresh the option values.
-    for (var i = 0; i < checkboxes.length; ++i) {
-      var checkbox = checkboxes[i];
-      options[checkbox.name] = checkbox.checked;
-    }
-
-    if (grammarChanged) {
-      grammarChanged = false;
-      saveEditorState(grammarEditor, 'grammar');
-
-      var result = parseGrammar(grammarEditor.getValue());
-      grammar = result.grammar;
-      updateExternalRules(grammarEditor, result.matchResult, grammar);
-      updateRuleHyperlinks(grammarEditor, result.matchResult, grammar);
-      if (result.error) {
-        var err = result.error;
-        setError('grammar', grammarEditor, err.interval, err.shortMessage || err.message);
-        return;
-      }
-    }
-
-    if (grammar && grammar.defaultStartRule) {
-      // TODO: Move this stuff to parseTree.js. We probably want a proper event system,
-      // with events like 'beforeGrammarParse' and 'afterGrammarParse'.
-      hideBottomOverlay();
-
-      var trace = grammar.trace(inputEditor.getValue());
-      if (trace.result.failed()) {
-        // Intervals with start == end won't show up in CodeMirror.
-        var interval = trace.result.getInterval();
-        interval.endIdx += 1;
-        setError('input', inputEditor, interval, 'Expected ' + trace.result.getExpectedText());
-      }
-
-      refreshParseTree(ui, grammar, trace, options.showFailures);
-    }
-  }
+  ohmEditor.ui.grammarEditor.on('change', function() {
+    grammarChanged = true;
+    hideError('grammar', ohmEditor.ui.grammarEditor);
+    triggerRefresh(250);
+  });
 
   /* eslint-disable no-console */
   console.log('%cOhm visualizer', 'color: #e0a; font-family: Avenir; font-size: 18px;');
   console.log([
     '- `ohm` is the Ohm library',
-    '- `grammar` is the current grammar object (if the source is valid)'
+    '- `ohmEditor` is editor object with',
+    '  `.grammar` as the current grammar object (if the source is valid)',
+    '  `.ui` containing the `inputEditor` and `grammarEditor`'
   ].join('\n'));
   /* eslint-enable no-console */
 
-  refresh();
+  grammarChanged = true;
+  ohmEditor.refresh();
 
   $$('.hiddenDuringLoading').forEach(function(el) {
     el.classList.remove('hiddenDuringLoading');
   });
-})();
+});

--- a/visualizer/parseTree.js
+++ b/visualizer/parseTree.js
@@ -2,13 +2,14 @@
 
 // Wrap the module in a universal module definition (UMD), allowing us to
 // either include it as a <script> or to `require` it as a CommonJS module.
-(function(root, name, initModule) {
+(function(root, initModule) {
   if (typeof exports === 'object') {
     module.exports = initModule;
   } else {
-    root[name] = initModule(root.ohm, root.document, root.cmUtil, root.d3);
+    root.ohmEditor = root.ohmEditor || {};
+    initModule(root.ohm, root.ohmEditor, root.document, root.cmUtil, root.d3);
   }
-})(this, 'refreshParseTree', function(ohm, document, cmUtil, d3) {
+})(this, function(ohm, ohmEditor, document, cmUtil, d3) {
   var ArrayProto = Array.prototype;
   function $(sel) { return document.querySelector(sel); }
 
@@ -456,5 +457,5 @@
     initializeWidths();
   }
 
-  return refreshParseTree;
+  ohmEditor.refreshParseTree = refreshParseTree;
 });

--- a/visualizer/ruleHyperlinks.js
+++ b/visualizer/ruleHyperlinks.js
@@ -1,9 +1,15 @@
 /* eslint-env browser */
-/* global cmUtil */
 
 'use strict';
 
-var updateRuleHyperlinks = (function() {  // eslint-disable-line no-unused-vars
+(function(root, initModule) {
+  if (typeof exports === 'object') {
+    module.exports = initModule;
+  } else {
+    root.ohmEditor = root.ohmEditor || {};
+    initModule(root.ohmEditor, root.cmUtil);
+  }
+})(this, function(ohmEditor, cmUtil) {
   var registeredListeners = false;
   var grammar;
   var grammarEditor;
@@ -108,7 +114,7 @@ var updateRuleHyperlinks = (function() {  // eslint-disable-line no-unused-vars
   }
 
   // Export a function to be called when the grammar contents change.
-  return function onGrammarChanged(editor, matchResult, g) {
+  ohmEditor.updateRuleHyperlinks = function onGrammarChanged(editor, matchResult, g) {
     if (!registeredListeners) {
       grammarEditor = editor;
       registerListeners(editor);
@@ -117,4 +123,4 @@ var updateRuleHyperlinks = (function() {  // eslint-disable-line no-unused-vars
     grammar = g;
     grammarPosInfos = matchResult.succeeded() ? matchResult.state.posInfos : null;
   };
-})();
+});

--- a/visualizer/searchBar.js
+++ b/visualizer/searchBar.js
@@ -1,8 +1,15 @@
-/* global $, CodeMirror */
+/* global $ */
 
 'use strict';
 
-var searchBar = (function() {  // eslint-disable-line no-unused-vars
+(function(root, initModule) {
+  if (typeof exports === 'object') {
+    module.exports = initModule;
+  } else {
+    root.ohmEditor = root.ohmEditor || {};
+    initModule(root.ohmEditor, root.CodeMirror);
+  }
+})(this, function(ohmEditor, CodeMirror) {
   // Returns the first ancestor node of `el` that has class `className`.
   function ancestorWithClassName(el, className) {
     var node = el;
@@ -103,10 +110,10 @@ var searchBar = (function() {  // eslint-disable-line no-unused-vars
   var editorKeyMap = {};
   editorKeyMap['Ctrl-F'] = editorKeyMap['Cmd-F'] = 'findPersistent';
 
-  return {
+  ohmEditor.searchBar = {
     // Initialize the search bar for the CodeMirror instance `cm`.
     initializeForEditor: function(cm) {
       cm.addKeyMap(editorKeyMap);
     }
   };
-})();
+});


### PR DESCRIPTION
... to create a public `ohmEditor` API and have only one global.

@pdubroy: How do you feel about that?
@lilyx: I know that this changes some things for the semantics editor as well, but my main goal was to refactor the code so I will have an easier way to programmatically load semantics. Please let me know any concerns and I am happy to work this refactoring into the changes on the `sv` branch!