### PR TITLE
Build on windows successfully

### DIFF
--- a/bin/build-debug.sh
+++ b/bin/build-debug.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ $npm_package_browserify_options ]; then
+  options=$npm_package_browserify_options
+else
+  options=$NPM_PACKAGE_BROWSERIFY_OPTIONS
+fi
+
+browserify $options

--- a/bin/build-debug.sh
+++ b/bin/build-debug.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [ $npm_package_browserify_options ]; then
-  options=$npm_package_browserify_options
-else
-  options=$NPM_PACKAGE_BROWSERIFY_OPTIONS
-fi
+options=${NPM_PACKAGE_BROWSERIFY_OPTIONS:-$npm_package_browserify_options}
 
 browserify $options

--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-if [ $npm_package_browserify_options ]; then
-  options=$npm_package_browserify_options
-else
-  options=$NPM_PACKAGE_BROWSERIFY_OPTIONS
-fi
+options=${NPM_PACKAGE_BROWSERIFY_OPTIONS:-$npm_package_browserify_options} 
 
 watchify -v $options

--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ $npm_package_browserify_options ]; then
+  options=$npm_package_browserify_options
+else
+  options=$NPM_PACKAGE_BROWSERIFY_OPTIONS
+fi
+
+watchify -v $options

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap": "bash bin/bootstrap --test || (echo 'Bootstrap failed.' && mv -v dist/ohm-grammar.js.old dist/ohm-grammar.js && mv -v dist/built-in-rules.js.old dist/built-in-rules.js && mv -v dist/operations-and-attributes.js.old dist/operations-and-attributes.js)",
     "build": "npm run build-debug && uglifyjs dist/ohm.js > dist/ohm.min.js",
     "prebuild-debug": "bash bin/update-env.sh",
-    "build-debug": "browserify $npm_package_browserify_options",
+    "build-debug": "bash bin/build-debug.sh",
     "clean": "rm -f dist/ohm.js dist/ohm.min.js",
     "deploy-gh-pages": "bin/deploy-gh-pages.sh",
     "lint": "eslint --rulesdir eslint_rules . && jscs --preset=google .",
@@ -38,7 +38,7 @@
     "prepublish": "npm run lint && npm run build && npm run bootstrap",
     "unsafe-bootstrap": "bash bin/bootstrap",
     "visualizer": "npm run watch & bin/ohm-visualizer",
-    "watch": "watchify $npm_package_browserify_options -v"
+    "watch": "bash bin/watch.sh"
   },
   "license": "MIT",
   "author": "Alex Warth <alexwarth@gmail.com> (http://tinlizzie.org/~awarth)",
@@ -46,7 +46,8 @@
     "Patrick Dubroy <pdubroy@gmail.com>",
     "Tony Garnock-Jones <tonygarnockjones@gmail.com>",
     "Yoshiki Ohshima <Yoshiki.Ohshima@acm.org>",
-    "Marko Röder <m.roeder@photon-software.de>"
+    "Marko Röder <m.roeder@photon-software.de>",
+    "Justin Chase <justin.m.chase@gmail.com>"
   ],
   "dependencies": {
     "es6-symbol": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "Patrick Dubroy <pdubroy@gmail.com>",
     "Tony Garnock-Jones <tonygarnockjones@gmail.com>",
     "Yoshiki Ohshima <Yoshiki.Ohshima@acm.org>",
-    "Marko Röder <m.roeder@photon-software.de>",
-    "Justin Chase <justin.m.chase@gmail.com>"
+    "Marko Röder <m.roeder@photon-software.de>"
   ],
   "dependencies": {
     "es6-symbol": "^2.0.1",


### PR DESCRIPTION
When npm runs on windows (even from git bash) it executes scripts as CMD
scripts. Using `$var` in these scripts causes issues on Windows.

Bash can be invoked however, so moving these scripts into shell files in
the bin directory allows the scripts to be completely bash while still
working on windows.