### PR TITLE
Ecmascript grammar accepts ohm

### DIFF
--- a/bin/build-debug.sh
+++ b/bin/build-debug.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ $npm_package_browserify_options ]; then
+    options=$npm_package_browserify_options
+else
+    options=$NPM_PACKAGE_BROWSERIFY_OPTIONS
+fi
+
+browserify $options

--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [ $npm_package_browserify_options ]; then
+    options=$npm_package_browserify_options
+else
+    options=$NPM_PACKAGE_BROWSERIFY_OPTIONS
+fi
+
+watchify -v $options

--- a/examples/ecmascript/README.md
+++ b/examples/ecmascript/README.md
@@ -9,6 +9,7 @@ working on ES6.
 You can install these grammars as an NPM package:
 
 ```
+npm install ohm-js
 npm install ohm-grammar-ecmascript
 ```
 
@@ -16,7 +17,11 @@ After installing, you can use the ES5 grammar like this:
 
 
 ```js
-var es5 = require('ohm-grammar-ecmascript');
+var ohm = require('ohm-js');
+var es = require('ohm-grammar-ecmascript');
+var es5 = es.es5(ohm);
+var es6 = es.es6(ohm); // in progress... 
+
 var result = es5.grammar.match('var x = 3; console.log(x);');
 assert(result.succeeded());
 ```

--- a/examples/ecmascript/compile.js
+++ b/examples/ecmascript/compile.js
@@ -9,8 +9,8 @@
 var fs = require('fs');
 var path = require('path');
 
-var es5 = require('./es5');
 var ohm = require('../..');
+var es5 = require('./es5')(ohm);
 
 // --------------------------------------------------------------------
 // Helpers

--- a/examples/ecmascript/es5.js
+++ b/examples/ecmascript/es5.js
@@ -9,8 +9,6 @@
 var fs = require('fs');
 var path = require('path');
 
-var ohm = require('../..');
-
 // --------------------------------------------------------------------
 // Helpers
 // --------------------------------------------------------------------
@@ -67,24 +65,26 @@ var modifiedSourceActions = {
   }
 };
 
-// Instantiate the ES5 grammar.
-var contents = fs.readFileSync(path.join(__dirname, 'es5.ohm'));
-var g = ohm.grammars(contents).ES5;
-var semantics = g.semantics();
+module.exports = function es5(ohm, ns, s) {
+  // Instantiate the ES5 grammar.
+  var contents = fs.readFileSync(path.join(__dirname, 'es5.ohm'));
+  var g = ohm.grammars(contents, ns).ES5;
+  var semantics = g.semantics(s);
 
-// An attribute whose value is either a string representing the modified source code for the
-// node, or undefined (which means that the original source code should be used).
-semantics.addAttribute('modifiedSource', modifiedSourceActions);
+  // An attribute whose value is either a string representing the modified source code for the
+  // node, or undefined (which means that the original source code should be used).
+  semantics.addAttribute('modifiedSource', modifiedSourceActions);
 
-// A simple wrapper around the `modifiedSource` attribute, which always returns a string
-// containing the ES5 source code for the node.
-semantics.addAttribute('asES5', {
-  _nonterminal: function(children) {
-    return isUndefined(this.modifiedSource) ? this.interval.contents : this.modifiedSource;
-  }
-});
+  // A simple wrapper around the `modifiedSource` attribute, which always returns a string
+  // containing the ES5 source code for the node.
+  semantics.addAttribute('asES5', {
+    _nonterminal: function(children) {
+      return isUndefined(this.modifiedSource) ? this.interval.contents : this.modifiedSource;
+    }
+  });
 
-module.exports = {
-  grammar: g,
-  semantics: semantics
+  return {
+    grammar: g,
+    semantics: semantics
+  };
 };

--- a/examples/ecmascript/index.js
+++ b/examples/ecmascript/index.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  es5: require('./es5'),
+  es6: require('./es6')
+};

--- a/examples/ecmascript/package.json
+++ b/examples/ecmascript/package.json
@@ -2,7 +2,7 @@
   "name": "ohm-grammar-ecmascript",
   "version": "0.5.0",
   "description": "Ohm grammars for various editions of ECMAScript (aka JavaScript).",
-  "main": "es5.js",
+  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/cdglabs/ohm/tree/master/examples/ecmascript#readme",
   "peerDependencies": {
-    "ohm-js": ">= 0.9.0"
+    "ohm-js": ">= 0.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bootstrap": "bash bin/bootstrap --test || (echo 'Bootstrap failed.' && mv -v dist/ohm-grammar.js.old dist/ohm-grammar.js && mv -v dist/built-in-rules.js.old dist/built-in-rules.js && mv -v dist/operations-and-attributes.js.old dist/operations-and-attributes.js)",
     "build": "npm run build-debug && uglifyjs dist/ohm.js > dist/ohm.min.js",
     "prebuild-debug": "bash bin/update-env.sh",
-    "build-debug": "browserify $npm_package_browserify_options",
+    "build-debug": "bash bin/build-debug.sh",
     "clean": "rm -f dist/ohm.js dist/ohm.min.js",
     "deploy-gh-pages": "bin/deploy-gh-pages.sh",
     "lint": "eslint --rulesdir eslint_rules . && jscs --preset=google .",
@@ -38,7 +38,7 @@
     "prepublish": "npm run lint && npm run build && npm run bootstrap",
     "unsafe-bootstrap": "bash bin/bootstrap",
     "visualizer": "npm run watch & bin/ohm-visualizer",
-    "watch": "watchify $npm_package_browserify_options -v"
+    "watch": "bash bin/watch.sh"
   },
   "license": "MIT",
   "author": "Alex Warth <alexwarth@gmail.com> (http://tinlizzie.org/~awarth)",
@@ -46,7 +46,8 @@
     "Patrick Dubroy <pdubroy@gmail.com>",
     "Tony Garnock-Jones <tonygarnockjones@gmail.com>",
     "Yoshiki Ohshima <Yoshiki.Ohshima@acm.org>",
-    "Marko Röder <m.roeder@photon-software.de>"
+    "Marko Röder <m.roeder@photon-software.de>",
+    "Justin Chase <justin.m.chase@gmail.com>"
   ],
   "dependencies": {
     "es6-symbol": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "Patrick Dubroy <pdubroy@gmail.com>",
     "Tony Garnock-Jones <tonygarnockjones@gmail.com>",
     "Yoshiki Ohshima <Yoshiki.Ohshima@acm.org>",
-    "Marko Röder <m.roeder@photon-software.de>",
-    "Justin Chase <justin.m.chase@gmail.com>"
+    "Marko Röder <m.roeder@photon-software.de>"
   ],
   "dependencies": {
     "es6-symbol": "^2.0.1",


### PR DESCRIPTION
- [ ] merge #96 

I was unable to use the ecmascript module right out of npm. This change allows it to be used and it exposes es5 and es6 with the same api.

This PR is dependent on PR #96 being merged first.

Requiring the module now loads index.js and the api is a little different, therefore I recommend bumping the major version of this library.