### PR TITLE
Improve es5 errors

### DIFF
--- a/examples/ecmascript/es5.ohm
+++ b/examples/ecmascript/es5.ohm
@@ -60,7 +60,7 @@ ES5 {
   multiLineComment = "/*" (~"*/" sourceCharacter)* "*/"
   singleLineComment = "//" (~lineTerminator sourceCharacter)*
 
-  identifier (an indentifier) = ~reservedWord identifierName
+  identifier (an identifier) = ~reservedWord identifierName
   identifierName = identifierStart identifierPart*
 
   identifierStart = letter | "$" | "_"

--- a/examples/ecmascript/es5.ohm
+++ b/examples/ecmascript/es5.ohm
@@ -395,7 +395,7 @@ ES5 {
 
   // §A.4 Statements -- http://ecma-international.org/ecma-262/5.1/#sec-A.4
 
-  Statement (a statement)
+  Statement
     = Block
     | VariableStatement
     | EmptyStatement


### PR DESCRIPTION
If there's a rule description on Statement, it masks a number of interesting errors. I saw this when extending the ES5 grammar for my Syndicate/js DSL. I add new cases to Statement expecting input such as `on message foo() { ... }`, and if I forget the `message`, I get an unhelpful error far away from the real problem. Removing the rule description from Statement gets me much more useful error reports.

(Separately, I've fixed a typo: `indentifier` => `identifier`.)