### PR TITLE
Allow ohm-cmd to generate recipe for ProtoBuiltInRules

### DIFF
--- a/src/Grammar.js
+++ b/src/Grammar.js
@@ -142,11 +142,6 @@ Grammar.prototype = {
   },
 
   toRecipe: function(optVarName) {
-    if (this.isBuiltIn()) {
-      throw new Error(
-          'Why would anyone want to generate a recipe for the ' + this.name + ' grammar?!?!');
-    }
-
     var metaInfo = {};
     // Include the grammar source if it is available.
     if (this.definitionInterval) {
@@ -154,7 +149,7 @@ Grammar.prototype = {
     }
 
     var superGrammar = null;
-    if (!this.superGrammar.isBuiltIn()) {
+    if (this.superGrammar && !this.superGrammar.isBuiltIn()) {
       superGrammar = JSON.parse(this.superGrammar.toRecipe());
     }
 
@@ -169,7 +164,7 @@ Grammar.prototype = {
       var body = self.ruleBodies[ruleName];
 
       var operation;
-      if (self.superGrammar.ruleBodies[ruleName]) {
+      if (self.superGrammar && self.superGrammar.ruleBodies[ruleName]) {
         operation = body instanceof pexprs.Extend ? 'extend' : 'override';
       } else {
         operation = 'define';
@@ -182,7 +177,8 @@ Grammar.prototype = {
       }
 
       var description = null;
-      if (!self.superGrammar.ruleBodies[ruleName] && self.ruleDescriptions[ruleName]) {
+      if (!(self.superGrammar && self.superGrammar.ruleBodies[ruleName]) &&
+          self.ruleDescriptions[ruleName]) {
         description = self.ruleDescriptions[ruleName];
       }
 
@@ -202,7 +198,7 @@ Grammar.prototype = {
       'grammar',
       metaInfo,
       this.name,
-      superGrammar,
+      superGrammar || null,
       startRule,
       rules
     ]);

--- a/src/Grammar.js
+++ b/src/Grammar.js
@@ -198,7 +198,7 @@ Grammar.prototype = {
       'grammar',
       metaInfo,
       this.name,
-      superGrammar || null,
+      superGrammar,
       startRule,
       rules
     ]);

--- a/src/Grammar.js
+++ b/src/Grammar.js
@@ -162,12 +162,13 @@ Grammar.prototype = {
     var self = this;
     Object.keys(this.ruleBodies).forEach(function(ruleName) {
       var body = self.ruleBodies[ruleName];
+      var isDefinition = !self.superGrammar || !self.superGrammar.ruleBodies[ruleName];
 
       var operation;
-      if (self.superGrammar && self.superGrammar.ruleBodies[ruleName]) {
-        operation = body instanceof pexprs.Extend ? 'extend' : 'override';
-      } else {
+      if (isDefinition) {
         operation = 'define';
+      } else {
+        operation = body instanceof pexprs.Extend ? 'extend' : 'override';
       }
 
       var metaInfo = {};
@@ -177,8 +178,7 @@ Grammar.prototype = {
       }
 
       var description = null;
-      if (!(self.superGrammar && self.superGrammar.ruleBodies[ruleName]) &&
-          self.ruleDescriptions[ruleName]) {
+      if (isDefinition && self.ruleDescriptions[ruleName]) {
         description = self.ruleDescriptions[ruleName];
       }
 

--- a/src/ohm-cmd.js
+++ b/src/ohm-cmd.js
@@ -8,19 +8,27 @@ var fs = require('fs');
 
 var args = process.argv.slice(2);
 if (args.length !== 1) {
-  console.error('usage: ' + process.argv[0] + ' ' + process.argv[1] + ' <ohm-grammar-file>');
+  console.error('usage: ' + process.argv[0] + ' ' + process.argv[1] +
+                ' { --builtin | <ohm-grammar-file> }');
   process.exit(1);  // eslint-disable-line no-process-exit
 }
 
 var filename = args[0];
-var source;
-try {
-  source = fs.readFileSync(filename).toString();
-} catch (e) {
-  console.error('error: cannot read file', filename);
-  process.exit(2);  // eslint-disable-line no-process-exit
+var grammar;
+
+if (filename === '--builtin') {
+  var Grammar = require('./Grammar');
+  grammar = Grammar.ProtoBuiltInRules;
+} else {
+  var source;
+  try {
+    source = fs.readFileSync(filename).toString();
+  } catch (e) {
+    console.error('error: cannot read file', filename);
+    process.exit(2);  // eslint-disable-line no-process-exit
+  }
+  grammar = ohm.grammar(source);
 }
 
-var grammar = ohm.grammar(source);
 console.log("var ohm = require('..');");
 console.log('module.exports = ohm.makeRecipe(' + grammar.toRecipe() + ');');

--- a/src/pexprs-outputRecipe.js
+++ b/src/pexprs-outputRecipe.js
@@ -27,11 +27,17 @@ function getMetaInfo(expr, grammarInterval) {
 pexprs.PExpr.prototype.outputRecipe = common.abstract('outputRecipe');
 
 pexprs.any.outputRecipe = function(formals, grammarInterval) {
-  throw new Error('should never output a recipe for `any` expression');
+  return [
+    'any',
+    getMetaInfo(this, grammarInterval)
+  ];
 };
 
 pexprs.end.outputRecipe = function(formals, grammarInterval) {
-  throw new Error('should never output a recipe for `end` expression');
+  return [
+    'end',
+    getMetaInfo(this, grammarInterval)
+  ];
 };
 
 pexprs.Terminal.prototype.outputRecipe = function(formals, grammarInterval) {
@@ -103,5 +109,13 @@ pexprs.Apply.prototype.outputRecipe = function(formals, grammarInterval) {
     this.args.map(function(arg) {
       return arg.outputRecipe(formals, grammarInterval);
     })
+  ];
+};
+
+pexprs.UnicodeChar.prototype.outputRecipe = function(formals, grammarInterval) {
+  return [
+    'unicodeChar',
+    getMetaInfo(this, grammarInterval),
+    this.category
   ];
 };


### PR DESCRIPTION
Allow ohm-cmd to generate recipe for ProtoBuiltInRules; useful for bootstrapping. (Second PR; I messed the first one up)