### PR TITLE
Visualizer: move `$` and `$$` to domUtil, and replace domcument queries.

### DIFF
--- a/visualizer/actionButton.js
+++ b/visualizer/actionButton.js
@@ -12,6 +12,8 @@
 
   // Privates
   // --------
+  var $ = domUtil.$;
+  var $$ = domUtil.$$;
 
   var UnicodeChars = {
     BLACK_UP_POINTING_TRIANGLE: '\u25B2',
@@ -22,8 +24,7 @@
 
   // Unselect all the semantics buttons, except the target semantic button
   function unselectOtherSemanticButtons(targetNameContainer) {
-    var wrappers = document.querySelectorAll('#semantics .wrapper');
-    Array.prototype.forEach.call(wrappers, function(wrapper) {
+    $$('#semantics .wrapper').forEach(function(wrapper) {
       var nameContainer = wrapper.querySelector('textarea.opName');
       if (targetNameContainer === nameContainer) {
         return;
@@ -87,7 +88,7 @@
   }
 
   function showActionMenu(e) {
-    var actionMenu = document.querySelector('#operationMenu');
+    var actionMenu = $('#operationMenu');
     actionMenu.style.left = e.clientX + 'px';
     actionMenu.style.top = e.clientY - 6 + 'px';
     actionMenu.hidden = false;
@@ -306,9 +307,7 @@
 
   // Add new operation or attribute wrapper
   function addNewSemanticButton(type) {
-    var container = type === 'Operation' ?
-        document.querySelector('#operations') :
-        document.querySelector('#attributes');
+    var container = type === 'Operation' ? $('#operations') : $('#attributes');
 
     // If the first semantic button in the list is not saved yet, return
     // without create a new one
@@ -400,20 +399,20 @@
     });
   }
 
-  var addOperationButton = document.querySelector('#addOperation');
+  var addOperationButton = $('#addOperation');
   addOperationButton.addEventListener('click', function(e) {
     addNewSemanticButton('Operation');
-    document.querySelector('#operations').firstElementChild.querySelector('.opName').focus();
+    $('#operations').firstElementChild.querySelector('.opName').focus();
   });
 
-  var addAttributeButton = document.querySelector('#addAttribute');
+  var addAttributeButton = $('#addAttribute');
   addAttributeButton.addEventListener('click', function(e) {
     addNewSemanticButton('Attribute');
-    document.querySelector('#attributes').firstElementChild.querySelector('.opName').focus();
+    $('#attributes').firstElementChild.querySelector('.opName').focus();
   });
 
   ohmEditor.addListener('parse:grammar', function(matchResult, grammar, error) {
-    document.querySelector('#operations').innerHTML = '';
-    document.querySelector('#attributes').innerHTML = '';
+    $('#operations').innerHTML = '';
+    $('#attributes').innerHTML = '';
   });
 });

--- a/visualizer/domUtil.js
+++ b/visualizer/domUtil.js
@@ -33,6 +33,10 @@
   // -------
 
   return {
+    $: function(sel) { return document.querySelector(sel); },
+
+    $$: function(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); },
+
     createElement: function(sel, optContent) {
       var parts = sel.split('.');
       var tagName = parts[0];

--- a/visualizer/index.js
+++ b/visualizer/index.js
@@ -6,20 +6,20 @@
   if (typeof exports === 'object') {
     module.exports = initModule;
   } else {
-    initModule(root.ohm, root.ohmEditor, root.cmUtil);
+    initModule(root.ohm, root.ohmEditor, root.cmUtil, root.domUtil);
   }
-})(this, function(ohm, ohmEditor, cmUtil) {
+})(this, function(ohm, ohmEditor, cmUtil, domUtil) {
   var checkboxes;
   var grammarChanged = true;
   var inputChanged = true;
 
   var showFailuresImplicitly = true;
 
+  var $ = domUtil.$;
+  var $$ = domUtil.$$;
+
   // Helpers
   // -------
-
-  function $(sel) { return document.querySelector(sel); }
-  function $$(sel) { return Array.prototype.slice.call(document.querySelectorAll(sel)); }
 
   function parseGrammar(source) {
     var matchResult = ohm.ohmGrammar.match(source);
@@ -122,8 +122,8 @@
     refreshTimeout = setTimeout(refresh.bind(ohmEditor), delay || 0);
   }
 
-  checkboxes = document.querySelectorAll('#options input[type=checkbox]');
-  Array.prototype.forEach.call(checkboxes, function(cb) {
+  checkboxes = $$('#options input[type=checkbox]');
+  checkboxes.forEach(function(cb) {
     cb.addEventListener('click', function(e) {
       // If the user manually disables "show failures", don't implicitly re-enable it.
       if (e.target.name === 'showFailures' && !e.target.checked) {

--- a/visualizer/parseTree.js
+++ b/visualizer/parseTree.js
@@ -11,7 +11,7 @@
   }
 })(this, function(ohm, ohmEditor, CheckedEmitter, document, cmUtil, d3, domUtil) {
   var ArrayProto = Array.prototype;
-  function $(sel) { return document.querySelector(sel); }
+  var $ = domUtil.$;
 
   var UnicodeChars = {
     ANTICLOCKWISE_OPEN_CIRCLE_ARROW: '\u21BA',

--- a/visualizer/searchBar.js
+++ b/visualizer/searchBar.js
@@ -1,14 +1,12 @@
-/* global $ */
-
 'use strict';
 
 (function(root, initModule) {
   if (typeof exports === 'object') {
     module.exports = initModule;
   } else {
-    initModule(root.ohmEditor, root.CodeMirror);
+    initModule(root.ohmEditor, root.domUtil, root.CodeMirror);
   }
-})(this, function(ohmEditor, CodeMirror) {
+})(this, function(ohmEditor, domUtil, CodeMirror) {
   // Returns the first ancestor node of `el` that has class `className`.
   function ancestorWithClassName(el, className) {
     var node = el;
@@ -89,7 +87,7 @@
     var container = ancestorWithClassName(editor.getWrapperElement(), 'flex-fix').parentNode;
     var footer = container.querySelector('.footer');
     if (!footer) {
-      footer = $('#protos .footer').cloneNode(true);
+      footer = domUtil.$('#protos .footer').cloneNode(true);
       container.appendChild(footer);
       footer.removeAttribute('hidden');
       installEventHandlers(editor, footer, callback);

--- a/visualizer/semanticsEditor.js
+++ b/visualizer/semanticsEditor.js
@@ -13,6 +13,8 @@
 
   // Privates
   // --------
+  var $ = domUtil.$;
+  var $$ = domUtil.$$;
 
   var UnicodeChars = {
     PLUS_SIGN: '\u002B',
@@ -107,14 +109,12 @@
     // Hover the block, and all the blocks that represent the results for the same operation
     // signature will be highlighted.
     block.onmouseover = function(event) {
-      var blocks = document.querySelectorAll('.semanticsEditor .result .' + blockClassId);
-      Array.prototype.forEach.call(blocks, function(b) {
+      $$('.semanticsEditor .result .' + blockClassId).forEach(function(b) {
         b.classList.add('highlight');
       });
     };
     block.onmouseout = function(event) {
-      var blocks = document.querySelectorAll('.semanticsEditor .result .' + blockClassId);
-      Array.prototype.forEach.call(blocks, function(b) {
+      $$('.semanticsEditor .result .' + blockClassId).forEach(function(b) {
         b.classList.remove('highlight');
       });
     };
@@ -598,7 +598,7 @@
       if (formals.length === 0) {
         entry.classList.add('disabled');
       }
-      document.querySelector('#parseTreeMenu').hidden = true;
+      $('#parseTreeMenu').hidden = true;
     };
 
     entry.onkeypress = function(event) {
@@ -613,7 +613,7 @@
         window.alert(error);    // eslint-disable-line no-alert
         return;
       }
-      document.querySelector('#parseTreeMenu').hidden = true;
+      $('#parseTreeMenu').hidden = true;
     };
     return entry;
   }


### PR DESCRIPTION
This moves the definition code for `$` & `$$` into domUtil, and replace `document.querySelector` and `document.querySelectorAll`