### PR TITLE
Viz: Change "Force evaluation" submenu to use triangle rather than +/-

### DIFF
--- a/visualizer/semanticsEditor.js
+++ b/visualizer/semanticsEditor.js
@@ -17,8 +17,7 @@
   var $$ = domUtil.$$;
 
   var UnicodeChars = {
-    PLUS_SIGN: '\u002B',
-    HYPHEN_MINUS: '\u002D',
+    BLACK_RIGHT_POINTING_TRIANGLE: '\u25B6',
     LEFTWARDS_ARROW: '\u2190'
   };
 
@@ -581,8 +580,7 @@
     var name = semanticOperation.name;
     var entry = domUtil.createElement('li');
     var formals = semanticOperation.formals;
-    entry.innerHTML = '<label></label>';
-    entry.firstChild.textContent = name;
+    entry.appendChild(domUtil.createElement('label', name));
     entry.appendChild(createArgumentsWrapper(formals));
 
     // Mark the entry `disabled` if semantics action of the operation is missing for the node,
@@ -649,17 +647,15 @@
     var editorWrapper = selfWrapper.querySelector('.semanticsEditor');
     var evaluatingSemantics = ohmEditor.semantics.appendEditor;
     var forceEntryContent = 'Force Evaluation';
-    forceEntryContent += '<span>' + (evaluatingSemantics ? UnicodeChars.PLUS_SIGN : '') +
-        '</span>';
+    forceEntryContent +=
+        '<span class="triangle">' + UnicodeChars.BLACK_RIGHT_POINTING_TRIANGLE + '</span>';
     var forceEntry = domUtil.addMenuItem('parseTreeMenu', 'forceEvaluation', forceEntryContent,
         evaluatingSemantics, function(event) { event.stopPropagation(); });
-    forceEntry.querySelector('span').className = 'sign';
     if (!evaluatingSemantics) {
       return;
     }
     // Hover the `Force Evaluation` entry to show forcing options
     forceEntry.onmouseover = function() {
-      forceEntry.querySelector('label span').innerHTML = UnicodeChars.HYPHEN_MINUS;
       var entryWrapper;
       if (forceEntry.querySelector('ul')) {
         entryWrapper = forceEntry.querySelector('ul');
@@ -668,9 +664,6 @@
         entryWrapper.hidden = true;
         addSemanticEntries(entryWrapper, traceNode, editorWrapper);
       }
-    };
-    forceEntry.onmouseout = function() {
-      forceEntry.querySelector('label span').innerHTML = UnicodeChars.PLUS_SIGN;
     };
   });
 

--- a/visualizer/style/semanticsEditor.css
+++ b/visualizer/style/semanticsEditor.css
@@ -225,8 +225,13 @@ headerBlock real {
 }
 
 /* `Force Evaluation` entry in `parseTreeMenu` */
-.contextMenu label .sign {
-  margin-left: 10px;
+.contextMenu label .triangle {
+  float: right;
+  font-size: 12px;
+  margin-left: 1em;
+  position: relative;
+  right: -10px;
+  top: 1px;
 }
 .contextMenu li div:not(:first-child), li textarea {
   margin-left: 10px;


### PR DESCRIPTION
@lilyx, please take a look.

I found the "+" and "-" characters on the "Force evaluation" menu item a bit confusing. I think it makes more sense to use a standard arrow symbol to indicate that there is a submenu.