### PR TITLE
toFailure is missing cases

### DIFF
--- a/src/pexprs-toFailure.js
+++ b/src/pexprs-toFailure.js
@@ -50,3 +50,9 @@ pexprs.Apply.prototype.toFailure = function(grammar) {
 pexprs.UnicodeChar.prototype.toFailure = function(grammar) {
   return new Failure(this, this.toDisplayString(), 'description');
 };
+
+pexprs.Alt.prototype.toFailure = function(grammar) {
+  var fs = this.terms.map(function(t) { return t.toFailure().getText(); });
+  var desc = '(' + fs.join(' or ') + ')';
+  return new Failure(this, desc, 'description');
+};

--- a/test/test-pexprs.js
+++ b/test/test-pexprs.js
@@ -145,3 +145,13 @@ test('toArgumentNameList', function(t) {
   t.deepEqual(pair.toArgumentNameList(1), ['$1', 'param0_1', '$3', 'param0_2', '$5']);
   t.end();
 });
+
+test('toFailure', function(t) {
+  var g = makeGrammar('G { start = ~("b" | "c") "d" }');
+  var r = g.match('b');
+  t.equal(r.failed(), true);
+  t.equal(typeof r.message, 'string'); // implicitly requires that r.message not throw
+  // t.comment(r.message);
+  t.ok(/Expected not \(b or c\)/.exec(r.message), 'reasonable failure report for Not-of-Alt');
+  t.end();
+});


### PR DESCRIPTION
I noticed this when a program written in a grammar parsed by Ohm had a syntax error involving a `Not` wrapping an `Alt`. When the `Not` was turned into a failure, it delegated to its child pexpr, the `Alt`, which has no `toFailure` implementation.

It can be reproduced by supplying input `"b"` to grammar

    G { start = ~("b" | "c") "d" }

(The supplied test case does exactly this.)

The commit so far only adds a case for `Alt`; really, the proper fix is probably to add all the other missing cases as well.

Or, it could be that this approach is mistaken - it is, after all, rather verbose! The implementation for `Alt` that I have supplied produces error messages of the form `(x or y or z or ...)`, which isn't great. Could an alternative make sense? What would it be, if so?