### PR TITLE
Make worker send 'received:neededExamples' on start

### DIFF
--- a/visualizer/exampleWorker.js
+++ b/visualizer/exampleWorker.js
@@ -82,13 +82,13 @@
                           args: [ruleName, examplesForRule]});
         break;
       case 'update:neededExamples':
-        var neededExamples = utils.difference(
+        generator.examplesNeeded = utils.difference(
           Object.keys(grammar.rules),
           Object.keys(generator.examplePieces)
         );
 
         self.postMessage({name: 'received:neededExamples',
-                          args: [neededExamples]});
+                          args: [generator.examplesNeeded]});
         break;
       case 'add:userExample':
         ruleName = e.data.args[0];
@@ -106,6 +106,9 @@
       Object.keys(grammar.rules),
       Object.keys(examplePieces)
     );
+    self.postMessage({name: 'received:neededExamples',
+                      args: [this.examplesNeeded]});
+
     this.currentRuleIndex = 0;
   }
 


### PR DESCRIPTION
In the example generation system, previously, if the example generation worker couldn't generate any examples, the UI would never get a list of needed examples for the worker. Now, on creation, the worker sends its list of needed examples to the UI.