### PR TITLE
substitute arguments for apply when making trace entry

### DIFF
--- a/src/State.js
+++ b/src/State.js
@@ -230,6 +230,12 @@ State.prototype = {
 
   // Returns a new trace entry, with the currently active trace array as its children.
   getTraceEntry: function(pos, expr, succeeded, bindings) {
+    if (expr instanceof pexprs.Apply) {
+      var app = this.currentApplication();
+      var actuals = app ? app.args : [];
+      expr = expr.substituteParams(actuals);
+    }
+
     return this.getMemoizedTraceEntry(pos, expr) ||
            new Trace(this.inputStream, pos, expr, succeeded, bindings, this.trace);
   },


### PR DESCRIPTION
Fixes #52 

This PR resolve the issue that the visualizer (and trace) do not always substitute argument with its supplied value. 

![current](https://cloud.githubusercontent.com/assets/11131839/20243648/9f6a6238-a92e-11e6-8855-5fa2e097c14c.png)

In state.eval(expr), expr.eval(state) is called to obtain the result, and then expr is used make the trace entry. The issue occurs because for the Apply expression, substituteParam, which supply the arguments with actual value, is called in expr.eval(state) to make a new Apply expression that is used for the result, while the expr that the state used for tracing is not substituted.

The PR addresses this problem by adding the substitution for Apply in getTraceEntry in State.